### PR TITLE
Check whether retrieved IP is in a Private Range

### DIFF
--- a/src/app/main.go
+++ b/src/app/main.go
@@ -8,12 +8,52 @@ import (
 	"app/gcloud"
 	"app/ip"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
 	"github.com/davecgh/go-spew/spew"
 	"log"
 	"os"
 	"strings"
 	"time"
 )
+
+
+// Credit to Brad Peabody and Dougnukem
+// https://stackoverflow.com/a/50825191
+var privateIPBlocks []*net.IPNet
+
+func init() {
+    for _, cidr := range []string{
+	        "127.0.0.0/8",    // IPv4 loopback
+	        "10.0.0.0/8",     // RFC1918
+	        "172.16.0.0/12",  // RFC1918
+	        "192.168.0.0/16", // RFC1918
+	        "169.254.0.0/16", // RFC3927 link-local
+	        "::1/128",        // IPv6 loopback
+	        "fe80::/10",      // IPv6 link-local
+	        "fc00::/7",       // IPv6 unique local addr
+    } {
+       _, block, err := net.ParseCIDR(cidr)
+       if err != nil {
+            panic(fmt.Errorf("parse error on %q: %v", cidr, err))
+       }
+       privateIPBlocks = append(privateIPBlocks, block)
+    }
+}
+
+func isPrivateIP(ip net.IP) bool {
+    if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+	        return true
+    }
+
+    for _, block := range privateIPBlocks {
+        if block.Contains(ip) {
+            return true
+        }
+    }
+    return false
+}
 
 func main() {
 	command := "help"
@@ -144,6 +184,21 @@ func readCurrentIP() string {
 	if err != nil {
 		log.Fatal("Failed to read current IP: ", err)
 	}
+
+	if isPrivateIP(net.ParseIP(currentIP)) {
+		//get IP from external source
+		resp, err := http.Get("https://ifconfig.me/ip")
+		if err != nil {
+			log.Fatal("Failed to issue http.Get request to https://ifconfig.me/ip: ", err)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal("Error reading response from https://ifconfig.me/ip: ", err)
+		}
+		currentIP = string(body)
+		defer resp.Body.Close()
+	}
+
 	return currentIP
 }
 


### PR DESCRIPTION
Resolves #1 

If the IP we get back from the interface is within a Private Range, it should not probably be used to update a public IP record as it would be unresolvable externally. Check the IP we retrieved against these known blocks and if it falls within one, use an external service (in this case https://ifconfig.me/ip) to retrieve the true public IP. A future enhancement could read a preferred IP-checking service from an environment variable. Expected return format is simply a string containing the public IP address. 